### PR TITLE
Introducing glob patterns to SCSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ help:
 .prefix:
 ifeq ($(OS), Windows_NT)
 	if not exist build mkdir build
-else#
+else
 	mkdir -p build
 endif
 


### PR DESCRIPTION
Not sure how 90% of these additions got included in the PR... I must've failed at something in git.

![image](https://cloud.githubusercontent.com/assets/122591/19543665/2cc35040-9647-11e6-9c3f-162332b3f10b.png)

But this PR introduces the ability to import SCSS files with glob patterns.

``` scss
@import "styles/**/*.scss";
@import "components/**/*.scss";
```
